### PR TITLE
Add support for scoped npm packages

### DIFF
--- a/fixtures/private-module-test/package.json
+++ b/fixtures/private-module-test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@someprivate/module-test",
+  "version": "0.0.0"
+}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,15 @@ module.exports = function (moduleId, opts) {
 	opts = opts || {};
 
 	var parts = moduleId.split(path.sep);
-	var pkg = path.join(parts.shift(), 'package.json');
+	var packageName = '';
+
+	if (parts.length > 0 && parts[0].indexOf('@') === 0) {
+		packageName += parts.shift() + path.sep;
+	}
+
+	packageName += parts.shift();
+
+	var pkg = path.join(packageName, 'package.json');
 	var resolved = resolveFrom(opts.cwd || '.', pkg);
 
 	if (!resolved) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "ava": "*",
     "grunt-svgmin": "3.1.0",
-    "xo": "*"
+    "xo": "*",
+    "@someprivate/module-test": "file:./fixtures/private-module-test"
   }
 }

--- a/test.js
+++ b/test.js
@@ -7,4 +7,6 @@ test(t => {
 	t.is(fn('nonexistent/foo'), null);
 	t.is(path.relative('.', fn('grunt-svgmin')), 'node_modules/grunt-svgmin');
 	t.is(path.relative('.', fn('grunt-svgmin/tasks')), 'node_modules/grunt-svgmin/tasks');
+	t.is(path.relative('.', fn('@someprivate/module-test')), 'node_modules/@someprivate/module-test');
+	t.is(path.relative('.', fn('@someprivate/module-test/subdir')), 'node_modules/@someprivate/module-test/subdir');
 });


### PR DESCRIPTION
Now supports scoped modules such as:

```
@myorg/mypackage
@myorg/mypackage/subdirectory
```
