### PR TITLE
Require Node.js 8, return `undefined` instead of `null`, add TypeScript definition

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.js text eol=lf
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '6'
-  - '4'
+  - '10'
+  - '8'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,36 @@
+declare namespace resolvePkg {
+	interface Options {
+		/**
+		Directory to resolve from.
+
+		@default process.cwd()
+		*/
+		readonly cwd?: string;
+	}
+}
+
+/**
+Resolve the path of a package regardless of it having an entry point.
+
+@param moduleId - What you would use in `require()`.
+
+@example
+```
+import resolvePkg = require('resolve-pkg');
+
+// $ npm install --save-dev grunt-svgmin
+
+resolvePkg('grunt-svgmin/tasks', {cwd: __dirname});
+//=> '/Users/sindresorhus/unicorn/node_modules/grunt-svgmin/tasks'
+
+// Fails here as Grunt tasks usually don't have a defined main entry point
+require.resolve('grunt-svgmin/tasks');
+//=> Error: Cannot find module 'grunt-svgmin'
+```
+*/
+declare function resolvePkg(
+	moduleId: string,
+	options?: resolvePkg.Options
+): string | undefined;
+
+export = resolvePkg;

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 const path = require('path');
 const resolveFrom = require('resolve-from');
 
-module.exports = (moduleId, opts) => {
-	opts = opts || {};
-
+module.exports = (moduleId, options = {}) => {
 	const parts = moduleId.replace(/\\/g, '/').split('/');
 	let packageName = '';
 
@@ -15,11 +13,11 @@ module.exports = (moduleId, opts) => {
 
 	packageName += parts.shift();
 
-	const pkg = path.join(packageName, 'package.json');
-	const resolved = resolveFrom(opts.cwd || process.cwd(), pkg);
+	const packageJson = path.join(packageName, 'package.json');
+	const resolved = resolveFrom.silent(options.cwd || process.cwd(), packageJson);
 
 	if (!resolved) {
-		return null;
+		return;
 	}
 
 	return path.join(path.dirname(resolved), parts.join('/'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from 'tsd';
+import resolvePkg = require('.');
+
+expectType<string | undefined>(resolvePkg('hello'));
+expectType<string | undefined>(resolvePkg('hello', {cwd: '.'}));

--- a/license
+++ b/license
@@ -1,21 +1,9 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,47 +1,49 @@
 {
-  "name": "resolve-pkg",
-  "version": "1.0.0",
-  "description": "Resolve the path of a package regardless of it having an entry point",
-  "license": "MIT",
-  "repository": "sindresorhus/resolve-pkg",
-  "author": {
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  },
-  "engines": {
-    "node": ">=4"
-  },
-  "scripts": {
-    "test": "xo && ava"
-  },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "require",
-    "resolve",
-    "path",
-    "module",
-    "from",
-    "like",
-    "path",
-    "cwd",
-    "current",
-    "working",
-    "directory",
-    "grunt",
-    "main",
-    "entry",
-    "point"
-  ],
-  "dependencies": {
-    "resolve-from": "^2.0.0"
-  },
-  "devDependencies": {
-    "@someprivate/module-test": "file:./fixtures/private-module-test",
-    "ava": "*",
-    "grunt-svgmin": "^4.0.0",
-    "xo": "*"
-  }
+	"name": "resolve-pkg",
+	"version": "1.0.0",
+	"description": "Resolve the path of a package regardless of it having an entry point",
+	"license": "MIT",
+	"repository": "sindresorhus/resolve-pkg",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"engines": {
+		"node": ">=8"
+	},
+	"scripts": {
+		"test": "xo && ava && tsd"
+	},
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
+	"keywords": [
+		"require",
+		"resolve",
+		"path",
+		"module",
+		"from",
+		"like",
+		"path",
+		"cwd",
+		"current",
+		"working",
+		"directory",
+		"grunt",
+		"main",
+		"entry",
+		"point"
+	],
+	"dependencies": {
+		"resolve-from": "^5.0.0"
+	},
+	"devDependencies": {
+		"@someprivate/module-test": "file:./fixtures/private-module-test",
+		"ava": "^1.4.1",
+		"grunt-svgmin": "^6.0.0",
+		"tsd": "^0.7.2",
+		"xo": "^0.24.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd"
+		"test": "xo && ava && tsd",
+		"postinstall": "del node_modules/@someprivate/module-test && make-dir node_modules/@someprivate/module-test && cpy 'fixtures/private-module-test/*' node_modules/@someprivate/module-test/"
 	},
 	"files": [
 		"index.js",
@@ -42,7 +43,10 @@
 	"devDependencies": {
 		"@someprivate/module-test": "file:./fixtures/private-module-test",
 		"ava": "^1.4.1",
+		"cpy-cli": "^2.0.0",
+		"del-cli": "^1.1.0",
 		"grunt-svgmin": "^6.0.0",
+		"make-dir-cli": "^2.0.0",
 		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd",
-		"postinstall": "del node_modules/@someprivate/module-test && make-dir node_modules/@someprivate/module-test && cpy 'fixtures/private-module-test/*' node_modules/@someprivate/module-test/"
+		"pretest": "del node_modules/@someprivate/module-test && make-dir node_modules/@someprivate/module-test && cpy 'fixtures/private-module-test/*' node_modules/@someprivate/module-test/",
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",

--- a/readme.md
+++ b/readme.md
@@ -2,13 +2,13 @@
 
 > Resolve the path of a package regardless of it having an entry point
 
-Some packages like CLI tools and grunt tasks don't have a entry point, like `"main": "foo.js"` in package.json, resulting in them not being resolvable by `require.resolve()`. Unlike `require.resolve()`, this module also resolves packages without an entry point, returns `null` instead of throwing when the module can't be found, and resolves from `process.cwd()` instead `__dirname` by default.
+Some packages like CLI tools and grunt tasks don't have a entry point, like `"main": "foo.js"` in package.json, resulting in them not being resolvable by `require.resolve()`. Unlike `require.resolve()`, this module also resolves packages without an entry point, returns `undefined` instead of throwing when the module can't be found, and resolves from `process.cwd()` instead `__dirname` by default.
 
 
 ## Install
 
 ```
-$ npm install --save resolve-pkg
+$ npm install resolve-pkg
 ```
 
 
@@ -42,7 +42,7 @@ What you would use in `require()`.
 
 ##### cwd
 
-Type: `boolean`<br>
+Type: `string`<br>
 Default: `process.cwd()`
 
 Directory to resolve from.

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
 import path from 'path';
 import test from 'ava';
-import m from './';
+import resolvePkg from '.';
 
-test(t => {
-	t.is(m('nonexistent'), null);
-	t.is(m('nonexistent/foo'), null);
-	t.is(path.relative('.', m('grunt-svgmin')), 'node_modules/grunt-svgmin');
-	t.is(path.relative('.', m('grunt-svgmin/tasks')), 'node_modules/grunt-svgmin/tasks');
-	t.is(path.relative('.', m('@someprivate/module-test')), 'node_modules/@someprivate/module-test');
-	t.is(path.relative('.', m('@someprivate/module-test/subdir')), 'node_modules/@someprivate/module-test/subdir');
+test('main', t => {
+	t.is(resolvePkg('nonexistent'), undefined);
+	t.is(resolvePkg('nonexistent/foo'), undefined);
+	t.is(path.relative('.', resolvePkg('grunt-svgmin')), 'node_modules/grunt-svgmin');
+	t.is(path.relative('.', resolvePkg('grunt-svgmin/tasks')), 'node_modules/grunt-svgmin/tasks');
+	t.is(path.relative('.', resolvePkg('@someprivate/module-test')), 'node_modules/@someprivate/module-test');
+	t.is(path.relative('.', resolvePkg('@someprivate/module-test/subdir')), 'node_modules/@someprivate/module-test/subdir');
 });


### PR DESCRIPTION
@sindresorhus Currently, tests fail because `npm@5` started to link packages installed from local paths (ones with `file:` urls) in contrast to older versions of npm which copied such packages over to `node_modules`.

I'm not sure how you would prefer to resolve this. Should we just manually copy the fixture package over to `node_modules`? Do you know of a better solution?

~~Waiting for https://github.com/sindresorhus/resolve-from/pull/12.~~